### PR TITLE
Fixed three tests

### DIFF
--- a/tests/testthat/test-nfold.R
+++ b/tests/testthat/test-nfold.R
@@ -20,7 +20,26 @@ test_that("nfold_trans", {
   expect_is(nfold_trans(), "transform")
 })
 
-test_that("scale_y/x_nfold", {
-  expect_equal(scale_y_nfold(), scale_y_continuous(trans = nfold_trans()))
-  expect_equal(scale_x_nfold(), scale_x_continuous(trans = nfold_trans()))
+test_that("scale_x_nfold", {
+  scale_n <- scale_x_nfold()
+  scale_n$call <- NULL
+  scale_n$super <- NULL
+
+  scale_cont <- scale_x_continuous(trans = nfold_trans())
+  scale_cont$call <- NULL
+  scale_cont$super <- NULL
+
+  expect_equal(scale_n, scale_cont)
+})
+
+test_that("scale_y_nfold", {
+  scale_n <- scale_y_nfold()
+  scale_n$call <- NULL
+  scale_n$super <- NULL
+
+  scale_cont <- scale_y_continuous(trans = nfold_trans())
+  scale_cont$call <- NULL
+  scale_cont$super <- NULL
+
+  expect_equal(scale_n, scale_cont)
 })

--- a/tests/testthat/test-nfold.R
+++ b/tests/testthat/test-nfold.R
@@ -17,7 +17,7 @@ test_that("nfold_breaks", {
 })
 
 test_that("nfold_trans", {
-  expect_is(nfold_trans(), "trans")
+  expect_is(nfold_trans(), "transform")
 })
 
 test_that("scale_y/x_nfold", {


### PR DESCRIPTION
`expect_equal(scale_y_nfold(), scale_y_continuous(trans = nfold_trans()))` fails because `scale_y_nfold()` and `scale_y_continuous(trans = nfold_trans())` have different function calls and inheritance structures. To fix this, I set `$call` and `$super` to `NULL`  as I doubt we need to test whether the function call and inheritance structure of these two objects are identical. Let me know if that isn't the case